### PR TITLE
ValidationDomainClassExtender tries to extend static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2025-02-06
+- Bytebuddy (ValidationDomainClassExtender) must not try to extend static methods
+
 ## [2.0.3] - 2025-01-29
 - Bugfix for proper handling of ValueObject duplicates in lists
 

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Gradle setup for a Spring Boot 3 app:
 
 ```Groovy
 dependencies{
-    implementation 'io.domainlifecycles:spring-boot-3-jooq-complete:2.0.1'
+    implementation 'io.domainlifecycles:spring-boot-3-jooq-complete:2.0.4'
 }
 ```
 
@@ -145,7 +145,7 @@ Maven setup for a Spring Boot 3 app:
 <dependency>
     <groupId>io.domainlifecycles</groupId>
     <artifactId>spring-boot-3-jooq-complete</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.4</version>
 </dependency>
 ```
 

--- a/validation-extender/build.gradle
+++ b/validation-extender/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     testImplementation project(":type-utils")
     testImplementation project(":assertions")
     testImplementation project(":test-shared-impl")
+    testImplementation project(":mirror")
     testImplementation "org.slf4j:slf4j-api:${slf4jVersion}"
     testImplementation "org.assertj:assertj-core:${assertJVersion}"
     testImplementation "org.projectlombok:lombok:${lombokVersion}"

--- a/validation-extender/src/main/java/io/domainlifecycles/validation/extend/ValidationDomainClassExtender.java
+++ b/validation-extender/src/main/java/io/domainlifecycles/validation/extend/ValidationDomainClassExtender.java
@@ -236,6 +236,7 @@ public class ValidationDomainClassExtender {
                                     ElementMatchers.isMethod()
                                         .and(ElementMatchers.not(
                                             ElementMatchers.returns(TypeDescription.ForLoadedType.of(void.class))))
+                                        .and(ElementMatchers.not(ElementMatchers.isStatic()))
                                         .and(ElementMatchers.not(ElementMatchers.hasMethodName("validate").and(
                                             ElementMatchers.takesNoArguments())))
                                         .and(ElementMatchers.not(ElementMatchers.hasMethodName("concurrencyVersion").and(

--- a/validation-extender/src/test/java/io/domainlifecycles/validation/extend/jakarta/VOStaticMethod.java
+++ b/validation-extender/src/test/java/io/domainlifecycles/validation/extend/jakarta/VOStaticMethod.java
@@ -8,4 +8,13 @@ public record VOStaticMethod(@NotNull Long value) implements ValueObject {
     public static void calculate(Long att) {
 
     }
+
+    private static void voidCalculatePrivate(Long att) {
+
+    }
+
+    private static Integer calculatePrivate(Long att) {
+
+        return 0;
+    }
 }

--- a/validation-extender/src/test/java/io/domainlifecycles/validation/extend/jakarta/ValidationExtensionWithDomainMirrorTest.java
+++ b/validation-extender/src/test/java/io/domainlifecycles/validation/extend/jakarta/ValidationExtensionWithDomainMirrorTest.java
@@ -1,0 +1,30 @@
+package io.domainlifecycles.validation.extend.jakarta;
+
+import io.domainlifecycles.mirror.api.Domain;
+import io.domainlifecycles.mirror.reflect.ReflectiveDomainMirrorFactory;
+import io.domainlifecycles.mirror.resolver.TypeMetaResolver;
+import io.domainlifecycles.validation.extend.ValidationDomainClassExtender;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@Slf4j
+class ValidationExtensionWithDomainMirrorTest {
+
+    @Test
+    void noExceptionThrown() {
+
+        final String[] packages = {"tests", "io.domainlifecycles.validation.extend"};
+
+        Locale.setDefault(Locale.ENGLISH);
+
+        Domain.setGenericTypeResolver(new TypeMetaResolver());
+        Domain.initialize(new ReflectiveDomainMirrorFactory(packages));
+
+        assertThatNoException()
+            .isThrownBy(() -> ValidationDomainClassExtender.extend(packages));
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -24,5 +24,5 @@
 #  limitations under the License.
 #
 
-version=2.0.3
+version=2.0.4
 


### PR DESCRIPTION
While static methods are excluded from the ValidationAdvice and the BeanValidationParameterAdvice this was not the case for the BeanValidationReturnValueAdvice therefore ByteBuddy tried to extend static methods which it can't. 

This causes an error "spamming" the console log when the extender is executed in combination with the DomainMirror initialization. An exception is thrown like this 
`java.lang.IllegalStateException: Cannot map this reference for static method or constructor start: private static java.lang.Integer io.domainlifecycles.validation.extend.jakarta.VOStaticMethod.calculatePrivate(java.lang.Long)`

This IllegalStateException can't be caught because it is (probably) thrown in another thread.