### PR TITLE
Custom exceptions for DomainAssertions PoC & Code separation for DomainAssertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2025-02-07
+- Allow to pass in an own Exception instead of a String to DomainAssertions
+- Split DomainAssertions into separate classes for better maintainability
+
 ## [2.0.3] - 2025-01-29
 - Bugfix for proper handling of ValueObject duplicates in lists
 

--- a/assertions/src/main/java/io/domainlifecycles/assertion/DomainAssertions.java
+++ b/assertions/src/main/java/io/domainlifecycles/assertion/DomainAssertions.java
@@ -51,7 +51,7 @@ import java.util.Optional;
  * <p>
  * If an assertion fails a DomainAssertionException is thrown.
  *
- * @author Mario Herb
+ * @author Mario Herb, Philipp Holz
  */
 public class DomainAssertions {
 
@@ -64,10 +64,21 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(Object anObject1, Object anObject2, String aMessage) {
-        if ((anObject1 != null && !anObject1.equals(anObject2))
-            || (anObject1 == null && anObject2 != null)) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(anObject1, anObject2, aMessage);
+    }
+
+    /**
+     * Compares two objects for equality. Two null object references are considered to be equal.
+     *
+     * @param anObject1 checked
+     * @param anObject2 compare value
+     * @param runtimeException exception that will be thrown
+     * @throws RuntimeException if check failed
+     */
+    public static void equals(Object anObject1, Object anObject2, RuntimeException runtimeException) {
+
+        DomainAssertionsEquals.equals(anObject1, anObject2, runtimeException);
     }
 
     /**
@@ -80,15 +91,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void optionalEquals(Optional anObjectOptional, Object anObject2, String aMessage) {
-        if (anObjectOptional == null) {
-            throw new IllegalArgumentException("The first parameter must not be null!");
-        }
-        if (anObjectOptional.isPresent()) {
-            Object anObject1 = anObjectOptional.get();
-            equals(anObject1, anObject2, aMessage);
-        } else if (anObjectOptional.isEmpty() && anObject2 != null) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.optionalEquals(anObjectOptional, anObject2, aMessage);
     }
 
     /**
@@ -100,9 +104,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(int aNumber1, int aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -114,9 +117,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(long aNumber1, long aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -128,9 +130,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(byte aNumber1, byte aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -142,9 +143,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(short aNumber1, short aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -156,9 +156,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(double aNumber1, double aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -170,9 +169,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(float aNumber1, float aNumber2, String aMessage) {
-        if (aNumber1 != aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -184,9 +182,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(char aChar1, char aChar2, String aMessage) {
-        if (aChar1 != aChar2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aChar1, aChar2, aMessage);
     }
 
     /**
@@ -198,9 +195,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void equals(boolean aBool1, boolean aBool2, String aMessage) {
-        if (aBool1 != aBool2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.equals(aBool1, aBool2, aMessage);
     }
 
     /**
@@ -212,10 +208,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(Object anObject1, Object anObject2, String aMessage) {
-        if ((anObject1 != null && anObject1.equals(anObject2))
-            || (anObject1 == null && anObject2 == null)) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(anObject1, anObject2, aMessage);
     }
 
     /**
@@ -228,15 +222,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void optionalNotEquals(Optional anOptionalObject1, Object anObject2, String aMessage) {
-        if (anOptionalObject1 == null) {
-            throw new IllegalArgumentException("The first parameter must not be null!");
-        }
-        if (anOptionalObject1.isPresent()) {
-            Object anObject1 = anOptionalObject1.get();
-            notEquals(anObject1, anObject2, aMessage);
-        } else if (anOptionalObject1.isEmpty() && anObject2 == null) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.optionalNotEquals(anOptionalObject1, anObject2, aMessage);
     }
 
     /**
@@ -248,9 +235,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(int aNumber1, int aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -263,9 +249,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(long aNumber1, long aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -277,9 +262,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(byte aNumber1, byte aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -291,9 +275,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(short aNumber1, short aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -305,9 +288,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(double aNumber1, double aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -319,9 +301,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(float aNumber1, float aNumber2, String aMessage) {
-        if (aNumber1 == aNumber2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aNumber1, aNumber2, aMessage);
     }
 
     /**
@@ -333,9 +314,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(char aChar1, char aChar2, String aMessage) {
-        if (aChar1 == aChar2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aChar1, aChar2, aMessage);
     }
 
     /**
@@ -347,9 +327,8 @@ public class DomainAssertions {
      * @throws DomainAssertionException if check failed
      */
     public static void notEquals(boolean aBool1, boolean aBool2, String aMessage) {
-        if (aBool1 == aBool2) {
-            throw new DomainAssertionException(aMessage);
-        }
+
+        DomainAssertionsEquals.notEquals(aBool1, aBool2, aMessage);
     }
 
     /**

--- a/assertions/src/main/java/io/domainlifecycles/assertion/DomainAssertionsEquals.java
+++ b/assertions/src/main/java/io/domainlifecycles/assertion/DomainAssertionsEquals.java
@@ -1,0 +1,205 @@
+/*
+ *     ___
+ *     │   ╲                 _
+ *     │    ╲ ___ _ __  __ _(_)_ _
+ *     |     ╲ _ ╲ '  ╲╱ _` │ │ ' ╲
+ *     |_____╱___╱_│_│_╲__,_│_│_||_|
+ *     │ │  (_)╱ _│___ __ _  _ __│ |___ ___
+ *     │ │__│ │  _╱ -_) _│ ││ ╱ _│ ╱ -_|_-<
+ *     │____│_│_│ ╲___╲__│╲_, ╲__│_╲___╱__╱
+ *                      |__╱
+ *
+ *  Copyright 2019-2024 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.domainlifecycles.assertion;
+
+import java.util.Optional;
+
+/**
+ * Assertions for equality of an object
+ * Package private class for separation concerns.
+ * API and javadoc is defined in {@link DomainAssertions}
+ * <p>
+ * If an assertion fails an either and passed RuntimeException or DomainAssertionException is thrown.
+ *
+ * @author Philipp Holz
+ */
+class DomainAssertionsEquals {
+
+    private DomainAssertionsEquals() {
+
+        throw new UnsupportedOperationException("This class should not be instantiated!");
+    }
+
+    static void equals(Object anObject1, Object anObject2, String aMessage) {
+
+        equals(anObject1, anObject2, new DomainAssertionException(aMessage));
+    }
+
+    static void equals(Object anObject1, Object anObject2, RuntimeException runtimeException) {
+
+        if ((anObject1 != null && !anObject1.equals(anObject2))
+            || (anObject1 == null && anObject2 != null)) {
+            throw runtimeException;
+        }
+    }
+
+    static void optionalEquals(Optional anObjectOptional, Object anObject2, String aMessage) {
+
+        if (anObjectOptional == null) {
+            throw new IllegalArgumentException("The first parameter must not be null!");
+        }
+        if (anObjectOptional.isPresent()) {
+            Object anObject1 = anObjectOptional.get();
+            equals(anObject1, anObject2, aMessage);
+        } else if (anObjectOptional.isEmpty() && anObject2 != null) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(int aNumber1, int aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(long aNumber1, long aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(byte aNumber1, byte aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(short aNumber1, short aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(double aNumber1, double aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(float aNumber1, float aNumber2, String aMessage) {
+
+        if (aNumber1 != aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(char aChar1, char aChar2, String aMessage) {
+
+        if (aChar1 != aChar2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void equals(boolean aBool1, boolean aBool2, String aMessage) {
+
+        if (aBool1 != aBool2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(Object anObject1, Object anObject2, String aMessage) {
+
+        if ((anObject1 != null && anObject1.equals(anObject2))
+            || (anObject1 == null && anObject2 == null)) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void optionalNotEquals(Optional anOptionalObject1, Object anObject2, String aMessage) {
+
+        if (anOptionalObject1 == null) {
+            throw new IllegalArgumentException("The first parameter must not be null!");
+        }
+        if (anOptionalObject1.isPresent()) {
+            Object anObject1 = anOptionalObject1.get();
+            notEquals(anObject1, anObject2, aMessage);
+        } else if (anOptionalObject1.isEmpty() && anObject2 == null) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(int aNumber1, int aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(long aNumber1, long aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(byte aNumber1, byte aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(short aNumber1, short aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(double aNumber1, double aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(float aNumber1, float aNumber2, String aMessage) {
+
+        if (aNumber1 == aNumber2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(char aChar1, char aChar2, String aMessage) {
+
+        if (aChar1 == aChar2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+
+    static void notEquals(boolean aBool1, boolean aBool2, String aMessage) {
+
+        if (aBool1 == aBool2) {
+            throw new DomainAssertionException(aMessage);
+        }
+    }
+}

--- a/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionException.java
+++ b/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionException.java
@@ -1,0 +1,18 @@
+package io.domainlifecycles.assertion;
+
+class CustomAssertionException extends RuntimeException {
+
+    private final CustomAssertionExceptionCode errorCode;
+
+    CustomAssertionException(final String message, final CustomAssertionExceptionCode errorCode) {
+
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    CustomAssertionExceptionCode exceptionCode() {
+
+        return errorCode;
+    }
+}
+

--- a/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionExceptionCode.java
+++ b/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionExceptionCode.java
@@ -1,0 +1,6 @@
+package io.domainlifecycles.assertion;
+
+enum CustomAssertionExceptionCode {
+
+    CUSTOM_ASSERTION_EXCEPTION_CODE_1,
+}

--- a/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionExceptions.java
+++ b/assertions/src/test/java/io/domainlifecycles/assertion/CustomAssertionExceptions.java
@@ -1,0 +1,9 @@
+package io.domainlifecycles.assertion;
+
+class CustomAssertionExceptions {
+
+    static CustomAssertionException defaultCustomAssertionException() {
+
+        return new CustomAssertionException("Failed", CustomAssertionExceptionCode.CUSTOM_ASSERTION_EXCEPTION_CODE_1);
+    }
+}

--- a/assertions/src/test/java/io/domainlifecycles/assertion/TestAssertionsEquals.java
+++ b/assertions/src/test/java/io/domainlifecycles/assertion/TestAssertionsEquals.java
@@ -7,6 +7,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestAssertionsEquals {
 
@@ -14,119 +17,146 @@ public class TestAssertionsEquals {
     class TestEquals {
 
         @Test
-        public void testObjectEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals("A", "B", "Failed")).isInstanceOf(
+        void testObjectEqualsFailCustomException() {
+
+            // org.junit.jupiter.api.assertThrows -> preferred lib?
+            final var exception = assertThrows(
+                CustomAssertionException.class,
+                () -> DomainAssertionsEquals.equals(
+                    "A",
+                    "B",
+                    CustomAssertionExceptions.defaultCustomAssertionException()
+                ));
+
+            assertThat(exception.exceptionCode())
+                .isEqualTo(CustomAssertionExceptionCode.CUSTOM_ASSERTION_EXCEPTION_CODE_1);
+
+            // this method is changed in a new assertj version, reversing the parameters.
+            // we should decide, which api we want to use. org.junit.jupiter or org.assertj
+            // org.assertj.core.api.catchThrowableOfType
+            final var exception2 = catchThrowableOfType(
+                () -> DomainAssertionsEquals.equals("A", "B", CustomAssertionExceptions.defaultCustomAssertionException()),
+                CustomAssertionException.class
+            );
+            assertThat(exception2.exceptionCode())
+                .isEqualTo(CustomAssertionExceptionCode.CUSTOM_ASSERTION_EXCEPTION_CODE_1);
+        }
+
+        @Test
+        void testObjectEqualsFail() {
+            // org.assertj.core.api.assertThatThrownBy -> replace with org.junit.jupiter.api.assertThrows
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals("A", "B", "Failed"))
+                .isInstanceOf(DomainAssertionException.class);
+        }
+
+        @Test
+        void testObjectEqualsNullFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals(null, "B", "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testObjectEqualsNullFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals(null, "B", "Failed")).isInstanceOf(
+        void testObjectEqualsNullCompareFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals("A", null, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testObjectEqualsNullCompareFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals("A", null, "Failed")).isInstanceOf(
+        void testObjectEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals("A", "A", "Failed"));
+        }
+
+        @Test
+        void testObjectEqualsBothNullOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals(null, null, "Failed"));
+        }
+
+        @Test
+        void testIntEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals(5, 6, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testObjectEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals("A", "A", "Failed"));
+        void testIntEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals(3, 3, "Failed"));
         }
 
         @Test
-        public void testObjectEqualsBothNullOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals(null, null, "Failed"));
-        }
-
-        @Test
-        public void testIntEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals(5, 6, "Failed")).isInstanceOf(
+        void testLongEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals(5l, 6l, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testIntEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals(3, 3, "Failed"));
+        void testLongEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals(3l, 3l, "Failed"));
         }
 
         @Test
-        public void testLongEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals(5l, 6l, "Failed")).isInstanceOf(
+        void testByteEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals((byte) 5, (byte) 6, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testLongEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals(3l, 3l, "Failed"));
+        void testByteEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals((byte) 3, (byte) 3, "Failed"));
         }
 
         @Test
-        public void testByteEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals((byte) 5, (byte) 6, "Failed")).isInstanceOf(
+        void testShortEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals((short) 5, (short) 6, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testByteEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals((byte) 3, (byte) 3, "Failed"));
+        void testShortEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals((short) 3, (short) 3, "Failed"));
         }
 
         @Test
-        public void testShortEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals((short) 5, (short) 6, "Failed")).isInstanceOf(
+        void testDoubleEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals(5.0, 6.0, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testShortEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals((short) 3, (short) 3, "Failed"));
+        void testDoubleEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals(3.0, 3.0, "Failed"));
         }
 
         @Test
-        public void testDoubleEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals(5.0, 6.0, "Failed")).isInstanceOf(
+        void testFloatEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals((float) 5.0, (float) 6.0, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testDoubleEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals(3.0, 3.0, "Failed"));
+        void testFloatEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals((float) 3.0, (float) 3.0, "Failed"));
         }
 
         @Test
-        public void testFloatEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals((float) 5.0, (float) 6.0, "Failed")).isInstanceOf(
+        void testCharEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals('a', 'b', "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testFloatEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals((float) 3.0, (float) 3.0, "Failed"));
+        void testCharEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals('x', 'x', "Failed"));
         }
 
         @Test
-        public void testCharEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals('a', 'b', "Failed")).isInstanceOf(
+        void testBooleanEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.equals(true, false, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testCharEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals('x', 'x', "Failed"));
-        }
-
-        @Test
-        public void testBooleanEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.equals(true, false, "Failed")).isInstanceOf(
-                DomainAssertionException.class);
-        }
-
-        @Test
-        public void testBooleanEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.equals(false, false, "Failed"));
+        void testBooleanEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.equals(false, false, "Failed"));
         }
     }
 
@@ -134,118 +164,118 @@ public class TestAssertionsEquals {
     class TestNotEquals {
 
         @Test
-        public void testObjectNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals("A", "A", "Failed")).isInstanceOf(
+        void testObjectNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals("A", "A", "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testObjectNotEqualsBothNullFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals(null, null, "Failed")).isInstanceOf(
+        void testObjectNotEqualsBothNullFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals(null, null, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testObjectNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals("A", "A1", "Failed"));
+        void testObjectNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals("A", "A1", "Failed"));
         }
 
         @Test
-        public void testObjectNotEqualsNullOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals(null, "A1", "Failed"));
+        void testObjectNotEqualsNullOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals(null, "A1", "Failed"));
         }
 
         @Test
-        public void testObjectNotEqualsNullParameterOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals("A", null, "Failed"));
+        void testObjectNotEqualsNullParameterOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals("A", null, "Failed"));
         }
 
         @Test
-        public void testIntNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals(5, 5, "Failed")).isInstanceOf(
+        void testIntNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals(5, 5, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testIntNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals(4, 3, "Failed"));
+        void testIntNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals(4, 3, "Failed"));
         }
 
         @Test
-        public void testLongNotNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals(8l, 8l, "Failed")).isInstanceOf(
+        void testLongNotNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals(8l, 8l, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testLongNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals(2l, 3l, "Failed"));
+        void testLongNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals(2l, 3l, "Failed"));
         }
 
         @Test
-        public void testByteNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals((byte) 6, (byte) 6, "Failed")).isInstanceOf(
+        void testByteNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals((byte) 6, (byte) 6, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testByteNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals((byte) 5, (byte) 3, "Failed"));
+        void testByteNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals((byte) 5, (byte) 3, "Failed"));
         }
 
         @Test
-        public void testShortNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals((short) 6, (short) 6, "Failed")).isInstanceOf(
+        void testShortNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals((short) 6, (short) 6, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testShortNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals((short) 6, (short) 3, "Failed"));
+        void testShortNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals((short) 6, (short) 3, "Failed"));
         }
 
         @Test
-        public void testDoubleNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals(6.0, 6.0, "Failed")).isInstanceOf(
+        void testDoubleNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals(6.0, 6.0, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testDoubleNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals(5.0, 3.0, "Failed"));
+        void testDoubleNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals(5.0, 3.0, "Failed"));
         }
 
         @Test
-        public void testFloatNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals((float) 5.0, (float) 5.0, "Failed")).isInstanceOf(
+        void testFloatNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals((float) 5.0, (float) 5.0, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testFloatNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals((float) 3.0, (float) 4.0, "Failed"));
+        void testFloatNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals((float) 3.0, (float) 4.0, "Failed"));
         }
 
         @Test
-        public void testCharNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals('a', 'a', "Failed")).isInstanceOf(
+        void testCharNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals('a', 'a', "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testCharNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals('x', 'f', "Failed"));
+        void testCharNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals('x', 'f', "Failed"));
         }
 
         @Test
-        public void testBooleanNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.notEquals(true, true, "Failed")).isInstanceOf(
+        void testBooleanNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.notEquals(true, true, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testBooleanNotEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.notEquals(false, true, "Failed"));
+        void testBooleanNotEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.notEquals(false, true, "Failed"));
         }
     }
 
@@ -253,36 +283,36 @@ public class TestAssertionsEquals {
     class TestOptionalEquals {
 
         @Test
-        public void testOptionalObjectEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalEquals(Optional.of("A"), "B", "Failed")).isInstanceOf(
+        void testOptionalObjectEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalEquals(Optional.of("A"), "B", "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testOptionalObjectEqualsEmptyFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalEquals(Optional.empty(), "B", "Failed")).isInstanceOf(
+        void testOptionalObjectEqualsEmptyFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalEquals(Optional.empty(), "B", "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testOptionalObjectEqualsFirstArgNullFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalEquals(null, "B", "Failed")).isInstanceOf(
+        void testOptionalObjectEqualsFirstArgNullFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalEquals(null, "B", "Failed")).isInstanceOf(
                 IllegalArgumentException.class);
         }
 
         @Test
-        public void testOptionalObjectEqualsEmptyOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.optionalEquals(Optional.empty(), null, "Failed"));
+        void testOptionalObjectEqualsEmptyOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.optionalEquals(Optional.empty(), null, "Failed"));
         }
 
         @Test
-        public void testOptionalObjectEqualsOk() {
-            assertThatNoException().isThrownBy(() -> DomainAssertions.optionalEquals(Optional.of("A"), "A", "Failed"));
+        void testOptionalObjectEqualsOk() {
+            assertThatNoException().isThrownBy(() -> DomainAssertionsEquals.optionalEquals(Optional.of("A"), "A", "Failed"));
         }
 
         @Test
-        public void testOptionalObjectEqualsSecondArgNullOk() {
-            assertThatThrownBy(() -> DomainAssertions.optionalEquals(Optional.of("A"), null, "Failed")).isInstanceOf(
+        void testOptionalObjectEqualsSecondArgNullOk() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalEquals(Optional.of("A"), null, "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
     }
@@ -291,31 +321,31 @@ public class TestAssertionsEquals {
     class TestOptionalNotEquals {
 
         @Test
-        public void testOptionalObjectNotEqualsFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalNotEquals(Optional.of("A"), "A", "Failed")).isInstanceOf(
+        void testOptionalObjectNotEqualsFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalNotEquals(Optional.of("A"), "A", "Failed")).isInstanceOf(
                 DomainAssertionException.class);
         }
 
         @Test
-        public void testOptionalObjectNotEqualsEmptyFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalNotEquals(Optional.empty(), null, "Failed"));
+        void testOptionalObjectNotEqualsEmptyFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalNotEquals(Optional.empty(), null, "Failed"));
         }
 
         @Test
-        public void testOptionalObjectNotEqualsOk() {
+        void testOptionalObjectNotEqualsOk() {
             assertThatNoException().isThrownBy(
-                () -> DomainAssertions.optionalNotEquals(Optional.of("A"), "Y", "Failed"));
+                () -> DomainAssertionsEquals.optionalNotEquals(Optional.of("A"), "Y", "Failed"));
         }
 
         @Test
-        public void testOptionalObjectNotEqualsEmptyOk() {
+        void testOptionalObjectNotEqualsEmptyOk() {
             assertThatNoException().isThrownBy(
-                () -> DomainAssertions.optionalNotEquals(Optional.empty(), "Y", "Failed"));
+                () -> DomainAssertionsEquals.optionalNotEquals(Optional.empty(), "Y", "Failed"));
         }
 
         @Test
-        public void testOptionalObjectNotEqualsNullFail() {
-            assertThatThrownBy(() -> DomainAssertions.optionalNotEquals(null, "A", "Failed")).isInstanceOf(
+        void testOptionalObjectNotEqualsNullFail() {
+            assertThatThrownBy(() -> DomainAssertionsEquals.optionalNotEquals(null, "A", "Failed")).isInstanceOf(
                 IllegalArgumentException.class);
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Gradle setup for a Spring Boot 3 app:
 
 ```Groovy
 dependencies{
-    implementation 'io.domainlifecycles:spring-boot-3-jooq-complete:2.0.1'
+    implementation 'io.domainlifecycles:spring-boot-3-jooq-complete:2.0.5'
 }
 ```
 
@@ -145,7 +145,7 @@ Maven setup for a Spring Boot 3 app:
 <dependency>
     <groupId>io.domainlifecycles</groupId>
     <artifactId>spring-boot-3-jooq-complete</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.5</version>
 </dependency>
 ```
 

--- a/version.properties
+++ b/version.properties
@@ -24,5 +24,5 @@
 #  limitations under the License.
 #
 
-version=2.0.3
+version=2.0.5
 


### PR DESCRIPTION
This is a Proof of Concept, for the ability to modify the behaviour DLC throws exceptions when running DomainAssertions.

Instead of passing in only a primitive String instance, we are now able to pass in a custom exception type that needs to extends a RuntimeException.
This gives us the opportunity e.g. to assert on exception codes instead of the message string within unittests which makes the tests less fragile (because we don't need to change the test, if we change the message of the exception) and at least gives more flexibility to operate and assert on an whole object instead of a single string.

Additional I've tried to split up the DomainAssertions a little bit. While keeping the API clear and conscious for the user with the public static DomainAsserions class, we could use package private classes to separate and test the logic of some assertion blocks, like equals, email, boolean, range etc. like we do already in the test suite. This will help us to keep the code more clean and organized. Since those classes are package private, they won't be exposed to the user of the library and therefore can't be accessed directly.